### PR TITLE
Stop using SafeAreaView on swiper cta

### DIFF
--- a/src/features/marketing/MarketingCarousel.js
+++ b/src/features/marketing/MarketingCarousel.js
@@ -9,7 +9,6 @@ import {
   StatusBar,
   StyleSheet,
   ImageBackground,
-  SafeAreaView,
   Linking,
 } from 'react-native';
 import Swiper from 'react-native-swiper';
@@ -298,19 +297,19 @@ export default class MarketingCarousel extends React.Component {
               this.props.setActiveMarketingScreen(index)
             }
             dot={
-              <SafeAreaView key={'dot'}>
+              <View key={'dot'}>
                 <View
                   style={[
                     marketingCarouselStyles.swiperDot,
                     isFirst && marketingCarouselStyles.swiperDotIsFirst,
                   ]}
                 />
-              </SafeAreaView>
+              </View>
             }
             activeDot={
-              <SafeAreaView key={'activeDot'}>
+              <View key={'activeDot'}>
                 <View style={marketingCarouselStyles.swiperDotIsActive} />
-              </SafeAreaView>
+              </View>
             }
             paginationStyle={marketingCarouselStyles.swiperPagination}
             loop={false}
@@ -368,10 +367,14 @@ export default class MarketingCarousel extends React.Component {
           </Swiper>
         </View>
 
-        <View style={marketingCarouselStyles.footerContainer}>
-          <SafeAreaView key={'footer'}>
+        <View
+          style={marketingCarouselStyles.footerContainer}
+          key="marketing-footer-container"
+        >
+          <View key="marketing-footer">
             {isFirst && (
               <TouchableOpacity
+                key="marketing-footer-policy"
                 style={marketingCarouselStyles.footerLoginContainer}
                 onPress={() => {
                   Linking.openURL('https://www.hedvig.com/privacy/');
@@ -384,7 +387,7 @@ export default class MarketingCarousel extends React.Component {
             )}
 
             <TouchableOpacity
-              key={'cta'}
+              key="marketing-footer-cta"
               onPress={() => this.props.startChat()}
               style={[
                 marketingCarouselStyles.footerCtaButton,
@@ -403,7 +406,7 @@ export default class MarketingCarousel extends React.Component {
             </TouchableOpacity>
             <View
               style={marketingCarouselStyles.footerLoginContainer}
-              key={'login'}
+              key="marketing-footer-login"
             >
               <View>
                 <Text
@@ -421,7 +424,7 @@ export default class MarketingCarousel extends React.Component {
                 </Text>
               </TouchableOpacity>
             </View>
-          </SafeAreaView>
+          </View>
         </View>
       </View>
     );

--- a/src/features/offer/OfferSwiper.js
+++ b/src/features/offer/OfferSwiper.js
@@ -8,7 +8,6 @@ import {
   AsyncStorage,
   Dimensions,
   TouchableOpacity,
-  SafeAreaView,
 } from 'react-native';
 import Swiper from 'react-native-swiper';
 import { connect } from 'react-redux';
@@ -34,6 +33,13 @@ import OfferScreen5 from './OfferScreen5';
 import OfferScreen6 from './OfferScreen6';
 import OfferScreen7 from './OfferScreen7';
 import OfferScreen8 from './OfferScreen8';
+
+import {
+  verticalSizeClass,
+  V_SPACIOUS,
+  V_REGULAR,
+  V_COMPACT,
+} from '../../services/DimensionSizes';
 
 const { width: viewportWidth, height: viewportHeight } = Dimensions.get(
   'window',
@@ -66,7 +72,11 @@ const styles = StyleSheet.create({
     marginRight: 5.5,
   },
   swiperPagination: {
-    bottom: 15,
+    bottom: {
+      [V_SPACIOUS]: 18,
+      [V_REGULAR]: 15,
+      [V_COMPACT]: 15,
+    }[verticalSizeClass],
   },
   button: {
     flexDirection: 'row',
@@ -80,7 +90,11 @@ const styles = StyleSheet.create({
     height: 47,
     zIndex: 200,
     elevation: 1,
-    marginBottom: 26,
+    marginBottom: {
+      [V_SPACIOUS]: 29,
+      [V_REGULAR]: 26,
+      [V_COMPACT]: 26,
+    }[verticalSizeClass],
   },
   buttonIsFirst: {
     backgroundColor: '#fff',
@@ -187,19 +201,19 @@ class OfferSwiper extends React.Component {
               alignItems: 'flex-end',
             }}
             dot={
-              <SafeAreaView key={'dot'}>
+              <View key={'dot'}>
                 <View style={styles.swiperDot} />
-              </SafeAreaView>
+              </View>
             }
             activeDot={
-              <SafeAreaView key={'activeDot'}>
+              <View key={'activeDot'}>
                 <View style={styles.swiperDotIsActive} />
-              </SafeAreaView>
+              </View>
             }
             paginationStyle={styles.swiperPagination}
             onIndexChanged={(index) => this.props.setActiveOfferScreen(index)}
             nextButton={
-              <SafeAreaView key={'nextButton'}>
+              <View key={'nextButton'}>
                 <View style={[styles.button, isFirst && styles.buttonIsFirst]}>
                   <Text style={[styles.label, isFirst && styles.labelIsFirst]}>
                     {isFirst ? 'Berätta mer' : 'Gå vidare'}
@@ -211,7 +225,7 @@ class OfferSwiper extends React.Component {
                     />
                   )}
                 </View>
-              </SafeAreaView>
+              </View>
             }
             prevButton={<View key={'prevButton'} />}
             width={viewportWidth}


### PR DESCRIPTION
The SafeAreaView component sometimes causes the element within
it to jitter/bounce around on iPhone X, as if the safe area padding is
being quicklu added and removed.

We don't loose much by removing it, layout is still decent on iPhone X.

Related issue: https://github.com/react-navigation/react-navigation/issues/3106